### PR TITLE
Previous failure doesn't stop current extension install

### DIFF
--- a/android/src/main/java/app/shosetsu/android/backend/workers/onetime/ExtensionInstallWorker.kt
+++ b/android/src/main/java/app/shosetsu/android/backend/workers/onetime/ExtensionInstallWorker.kt
@@ -350,7 +350,7 @@ class ExtensionInstallWorker(appContext: Context, params: WorkerParameters) : Co
 				logI(LogConstants.SERVICE_NEW)
 				workerManager.enqueueUniqueWork(
 					EXTENSION_INSTALL_WORK_ID,
-					ExistingWorkPolicy.APPEND,
+					ExistingWorkPolicy.APPEND_OR_REPLACE,
 					OneTimeWorkRequestBuilder<ExtensionInstallWorker>().setInputData(data).build()
 				)
 				logI(


### PR DESCRIPTION
Fixes #161 
Fixes #163
![imagen](https://user-images.githubusercontent.com/1996449/143327859-2b0d78a0-d58e-414d-9148-63c61e302862.png)
This is the first time I've seen a tooltip describe both the problem and the solution. Tested and it fixes both issues. With APPEND it can install multiple extensions at once, but it'll block all future jobs with a failure, either by LuaError or by being offline. With APPEND_OR_REPLACE it can install multiple extensions at once, and if it fails it doesn't affect future installs.