### PR TITLE
Disallow opening duplicate FILTER pop-ups

### DIFF
--- a/android/src/main/java/app/shosetsu/android/ui/browse/BrowseController.kt
+++ b/android/src/main/java/app/shosetsu/android/ui/browse/BrowseController.kt
@@ -59,6 +59,7 @@ import com.mikepenz.fastadapter.binding.listeners.addLongClickListener
 class BrowseController : FastAdapterRecyclerController<ControllerBrowseBinding, ExtensionUI>(),
 	ExtendedFABController {
 	override val viewTitleRes: Int = R.string.browse
+	private var bsg: BottomSheetDialog? = null
 
 	init {
 		setHasOptionsMenu(true)
@@ -205,32 +206,36 @@ class BrowseController : FastAdapterRecyclerController<ControllerBrowseBinding, 
 		this.fab = fab
 		fab.setOnClickListener {
 			//bottomMenuRetriever.invoke()?.show()
-			BottomSheetDialog(this.view!!.context).apply {
-				val binding = ComposeViewBinding.inflate(
-					this@BrowseController.activity!!.layoutInflater,
-					null,
-					false
-				)
-
-				this.window?.decorView?.let {
-					ViewTreeLifecycleOwner.set(it, this@BrowseController)
-					ViewTreeSavedStateRegistryOwner.set(it, activity as MainActivity)
-				}
-
-				binding.root.apply {
-					setViewCompositionStrategy(
-						ViewCompositionStrategy.DisposeOnLifecycleDestroyed(this@BrowseController)
+			if (bsg == null)
+				bsg = BottomSheetDialog(this.view!!.context)
+			if (bsg?.isShowing() == false) {
+				bsg?.apply {
+					val binding = ComposeViewBinding.inflate(
+						this@BrowseController.activity!!.layoutInflater,
+						null,
+						false
 					)
-					setContent {
-						MdcTheme(view!!.context) {
-							BrowseControllerFilterMenu(viewModel)
+
+					this.window?.decorView?.let {
+						ViewTreeLifecycleOwner.set(it, this@BrowseController)
+						ViewTreeSavedStateRegistryOwner.set(it, activity as MainActivity)
+					}
+
+					binding.root.apply {
+						setViewCompositionStrategy(
+							ViewCompositionStrategy.DisposeOnLifecycleDestroyed(this@BrowseController)
+						)
+						setContent {
+							MdcTheme(view!!.context) {
+								BrowseControllerFilterMenu(viewModel)
+							}
 						}
 					}
-				}
 
-				setContentView(binding.root)
+					setContentView(binding.root)
 
-			}.show()
+				}?.show()
+			}
 		}
 		fab.setText(R.string.filter)
 		fab.setIconResource(R.drawable.filter)

--- a/android/src/main/java/app/shosetsu/android/ui/catalogue/CatalogController.kt
+++ b/android/src/main/java/app/shosetsu/android/ui/catalogue/CatalogController.kt
@@ -67,6 +67,7 @@ class CatalogController(
 	val bundle: Bundle,
 ) : FastAdapterRecyclerController<ControllerCatalogueBinding, ACatalogNovelUI>(bundle),
 	ExtendedFABController {
+	private var bsg: BottomSheetDialog? = null
 
 	/***/
 	val viewModel: ACatalogViewModel by viewModel()
@@ -320,32 +321,36 @@ class CatalogController(
 		fab.setIconResource(R.drawable.filter)
 		fab.setOnClickListener {
 			//bottomMenuRetriever.invoke()?.show()
-			BottomSheetDialog(this.view!!.context).apply {
-				val binding = ComposeViewBinding.inflate(
-					this@CatalogController.activity!!.layoutInflater,
-					null,
-					false
-				)
-
-				this.window?.decorView?.let {
-					ViewTreeLifecycleOwner.set(it, this@CatalogController)
-					ViewTreeSavedStateRegistryOwner.set(it, activity as MainActivity)
-				}
-
-				binding.root.apply {
-					setViewCompositionStrategy(
-						ViewCompositionStrategy.DisposeOnLifecycleDestroyed(this@CatalogController)
+			if (bsg == null)
+				bsg = BottomSheetDialog(this.view!!.context)
+			if (bsg?.isShowing() == false) {
+				bsg?.apply {
+					val binding = ComposeViewBinding.inflate(
+						this@CatalogController.activity!!.layoutInflater,
+						null,
+						false
 					)
-					setContent {
-						MdcTheme(view!!.context) {
-							CatalogFilterMenu(viewModel)
+
+					this.window?.decorView?.let {
+						ViewTreeLifecycleOwner.set(it, this@CatalogController)
+						ViewTreeSavedStateRegistryOwner.set(it, activity as MainActivity)
+					}
+
+					binding.root.apply {
+						setViewCompositionStrategy(
+							ViewCompositionStrategy.DisposeOnLifecycleDestroyed(this@CatalogController)
+						)
+						setContent {
+							MdcTheme(view!!.context) {
+								CatalogFilterMenu(viewModel)
+							}
 						}
 					}
-				}
 
-				setContentView(binding.root)
+					setContentView(binding.root)
 
-			}.show()
+				}?.show()
+			}
 		}
 	}
 }

--- a/android/src/main/java/app/shosetsu/android/ui/library/LibraryController.kt
+++ b/android/src/main/java/app/shosetsu/android/ui/library/LibraryController.kt
@@ -59,6 +59,7 @@ class LibraryController
 	: FastAdapterRefreshableRecyclerController<ABookmarkedNovelUI>(), ExtendedFABController {
 
 	private var fab: ExtendedFloatingActionButton? = null
+	private var bsg: BottomSheetDialog? = null
 
 	override val viewTitleRes: Int = R.string.my_library
 
@@ -325,9 +326,13 @@ class LibraryController
 		this.fab = fab
 		fab.setOnClickListener {
 			//bottomMenuRetriever.invoke()?.show()
-			BottomSheetDialog(binding.root.context).apply {
-				setContentView(getBottomMenuView())
-			}.show()
+			if (bsg == null)
+				bsg = BottomSheetDialog(binding.root.context)
+			if (bsg?.isShowing() == false) {
+				bsg?.apply {
+					setContentView(getBottomMenuView())
+				}?.show()
+			}
 		}
 		fab.setText(R.string.filter)
 		fab.setIconResource(R.drawable.filter)


### PR DESCRIPTION
Fixes #167
I'm not sure I did this right, but seems to work.
```kt
//Lazy loading prevented me from initializing it immediately, so it's null.
private var bsg: BottomSheetDialog? = null
⋮
if (bsg == null)
	//I create a single BottomSheetDialog to edit the contents of and show
	//one for the library, one for the list of extensions, one for an extension's catalog
	bsg = BottomSheetDialog(binding.root.context)
//For the list of extensions filter, it fills the dialog with an empty Languages group, then later it fills in en jp zn pt ar es. If I allow running .apply every time I hit FILTER, it'll crash the second time it tries to fill in the Languages on the single pop-up it shows.
//I want to invert isShowing but the type is null or boolean and null can't be inverted, so I just check for false. I don't think it can actually be null by this point.
if (bsg?.isShowing() == false) {
	//Because it starts null, I have to use ?. instead of .
	bsg?.apply {
		//It gets created once, modified multiple times
		setContentView(getBottomMenuView())
	}?.show()
}
```