### PR TITLE
Fix dropdown text color, unclickable space

### DIFF
--- a/android/src/main/java/app/shosetsu/android/ui/catalogue/CatalogueFilterMenu.kt
+++ b/android/src/main/java/app/shosetsu/android/ui/catalogue/CatalogueFilterMenu.kt
@@ -2,10 +2,10 @@ package app.shosetsu.android.ui.catalogue
 
 import android.annotation.SuppressLint
 import android.util.Log
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material.*
 import androidx.compose.runtime.*
 import androidx.compose.runtime.livedata.observeAsState
@@ -467,11 +467,12 @@ fun CatalogFilterMenuDropDownContent(viewModel: ACatalogViewModel, filter: Filte
 		Row(
 			verticalAlignment = Alignment.CenterVertically,
 		) {
-			ClickableText(
+			Text(
 				text = AnnotatedString(filter.choices[selection]),
-			) {
-				expanded = true
-			}
+				modifier = Modifier.clickable(onClick = {
+					expanded = true
+				})
+			)
 			IconToggleButton(
 				onCheckedChange = {
 					expanded = it
@@ -490,13 +491,14 @@ fun CatalogFilterMenuDropDownContent(viewModel: ACatalogViewModel, filter: Filte
 				onDismissRequest = { expanded = false },
 			) {
 				filter.choices.forEachIndexed { i, s ->
-					ClickableText(
+					//DropdownMenuItem(
+					Text(
 						text = AnnotatedString(s),
-						modifier = Modifier.padding(8.dp),
-						onClick = {
+						modifier = Modifier.padding(8.dp).clickable(onClick = {
 							viewModel.setFilterIntState(filter, i)
 							expanded = false
 						})
+					)
 				}
 			}
 		}

--- a/android/src/main/java/app/shosetsu/android/ui/catalogue/CatalogueFilterMenu.kt
+++ b/android/src/main/java/app/shosetsu/android/ui/catalogue/CatalogueFilterMenu.kt
@@ -491,14 +491,15 @@ fun CatalogFilterMenuDropDownContent(viewModel: ACatalogViewModel, filter: Filte
 				onDismissRequest = { expanded = false },
 			) {
 				filter.choices.forEachIndexed { i, s ->
-					//DropdownMenuItem(
-					Text(
-						text = AnnotatedString(s),
-						modifier = Modifier.padding(8.dp).clickable(onClick = {
+					DropdownMenuItem(
+						onClick = {
 							viewModel.setFilterIntState(filter, i)
 							expanded = false
-						})
-					)
+						}) {
+						Text(
+							text = AnnotatedString(s)
+						)
+					}
 				}
 			}
 		}

--- a/android/src/main/java/app/shosetsu/android/view/compose/setting/DropdownSettingContent.kt
+++ b/android/src/main/java/app/shosetsu/android/view/compose/setting/DropdownSettingContent.kt
@@ -97,14 +97,15 @@ fun DropdownSettingContent(
 				onDismissRequest = { expanded = false },
 			) {
 				choices.forEachIndexed { index, s ->
-					//DropdownMenuItem(
-					Text(
-						text = AnnotatedString(s),
-						modifier = Modifier.padding(8.dp).clickable(onClick = {
+					DropdownMenuItem(
+						onClick = {
 							onSelection(index)
 							expanded = false
-						})
-					)
+					}) {
+						Text(
+							text = AnnotatedString(s)
+						)
+					}
 				}
 			}
 		}

--- a/android/src/main/java/app/shosetsu/android/view/compose/setting/DropdownSettingContent.kt
+++ b/android/src/main/java/app/shosetsu/android/view/compose/setting/DropdownSettingContent.kt
@@ -1,12 +1,14 @@
 package app.shosetsu.android.view.compose.setting
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentWidth
-import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material.DropdownMenu
+import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.Icon
 import androidx.compose.material.IconToggleButton
+import androidx.compose.material.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -72,11 +74,12 @@ fun DropdownSettingContent(
 		Row(
 			verticalAlignment = Alignment.CenterVertically,
 		) {
-			ClickableText(
+			Text(
 				text = AnnotatedString(choices[selection]),
-			) {
-				expanded = true
-			}
+				modifier = Modifier.clickable(onClick = {
+					expanded = true
+				})
+			)
 			IconToggleButton(
 				onCheckedChange = {
 					expanded = it
@@ -94,13 +97,14 @@ fun DropdownSettingContent(
 				onDismissRequest = { expanded = false },
 			) {
 				choices.forEachIndexed { index, s ->
-					ClickableText(
+					//DropdownMenuItem(
+					Text(
 						text = AnnotatedString(s),
-						modifier = Modifier.padding(8.dp),
-						onClick = {
+						modifier = Modifier.padding(8.dp).clickable(onClick = {
 							onSelection(index)
 							expanded = false
 						})
+					)
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #159

reference: https://foso.github.io/Jetpack-Compose-Playground/material/dropdownmenu/
reference: https://material.io/components/menus#specs
I couldn't find how to style ClickableText, and the example uses Text anyway, so I switched it to that.
Using DropdownMenuItem makes clickable the space to the right of the text and between items, and increases the height of each item from 25dp to 48dp.